### PR TITLE
refactor: Change PyInstaller command to use `python -m PyInstaller`

### DIFF
--- a/roseui/v8.pyw
+++ b/roseui/v8.pyw
@@ -221,9 +221,9 @@ def _makebuild(q: Queue, data_builder) -> str:
     def compile():
         try:
             logger.info("Entering compile process")
-            logger.info(f'Compile CMD Line: pyinstaller "{path}\main.py" --noconsole --onefile')
+            logger.info(f'Compile CMD Line: python -m PyInstaller "{path}\main.py" --noconsole --onefile')
             output_file = "rosecompile.log"
-            subprocess.call(f'pyinstaller "{path}\main.py" --noconsole --onefile', shell=True, stdout=open(output_file, 'w'), stderr=subprocess.STDOUT)
+            subprocess.call(f'python -m PyInstaller "{path}\main.py" --noconsole --onefile', shell=True, stdout=open(output_file, 'w'), stderr=subprocess.STDOUT)
             logger.info(f"Output of compile process saved in rosecompile.log")
         except Exception as e:
             logger.error(f"Error in compile: {e}")

--- a/tools/rose_builder.pyw
+++ b/tools/rose_builder.pyw
@@ -131,7 +131,7 @@ class Runnable_wf(QRunnable):
                 f.write(new)
                 
     def compile(self):
-        os.system(f'pyinstaller "{self.path}/main.py" --noconsole --onefile')
+        os.system(f'python -m PyInstaller "{self.path}/main.py" --noconsole --onefile')
         
     def move_dir(self): 
         shutil.move(f"dist\\main.exe", f"{self.dir_name}.exe")


### PR DESCRIPTION
This commit refactors the `compile` function in `v8.pyw` to use the `python -m PyInstaller` command instead of calling `PyInstaller` directly. This change was made to ensure that the correct version of `PyInstaller` is used, as well as to make the command more consistent with other Python commands. Additionally, this change allows the `compile` function to work even when `PyInstaller` is not in the system path.